### PR TITLE
Planner throws exception about Node ARRAY that could not be implemented

### DIFF
--- a/lingual-platform/src/test/java/cascading/lingual/jdbc/SimpleSqlPlatformTest.java
+++ b/lingual-platform/src/test/java/cascading/lingual/jdbc/SimpleSqlPlatformTest.java
@@ -297,4 +297,32 @@ public class SimpleSqlPlatformTest extends JDBCPlatformTestCase
     assertTablesEqual( "emps-depts-sum-count-groupby",
       "select emps.deptno, sum( emps.age ) as s1, count( distinct emps.city ) as c1 from sales.emps, sales.depts where emps.deptno = depts.deptno group by emps.deptno" );
     }
+  
+  @Test
+  public void testPlannerArrayNotImplemented() throws Exception
+    {
+    String query = "SELECT p0.city, p1.city, p1.empno, p0.empno " +
+      "FROM sales.emps AS p0 " +
+      "INNER JOIN sales.emps AS p1 ON (p1.gender = 'M' ) " +
+      "LEFT JOIN sales.emps AS p2 ON (p2.gender = 'M' " +
+      "AND p2.empno = p1.empno " +
+      "AND ( NOT(CASE WHEN (p0.age IS NOT NULL OR p2.age IS NOT NULL ) " +
+      "THEN p0.age IS NOT NULL " +
+      "AND p2.age IS NOT NULL " +
+      "AND p0.age = p2.age " +
+      "AND p0.city = p2.city " +
+      "WHEN (p0.name IS NULL " +
+      "OR p0.name = 'Bob' ) " +
+      "AND (p2.name IS NULL " +
+      "OR p2.name = 'Bob' ) " +
+      "THEN p0.city = p2.city " +
+      "WHEN p0.name = p2.name " +
+      "AND p0.city = p2.city " +
+      "THEN  1=1  END))) " +
+      "WHERE p0.gender = 'M' " +
+      "AND p2.city IS NULL"; 
+    
+    assertTablesEqual( "emps-planner-array-not-implemented", query );
+    }
+  
   }

--- a/lingual-platform/src/test/resources/data/expected/emps-planner-array-not-implemented.tcsv
+++ b/lingual-platform/src/test/resources/data/expected/emps-planner-array-not-implemented.tcsv
@@ -1,0 +1,1 @@
+CITY:string,CITY0:string,EMPNO:int,EMPNO0:int


### PR DESCRIPTION
A second issue I have encountered. This one seems to come from the eigenbase RelOptPlanner (see part of the stack trace below).
Attached a unit test that exposes the problem (the SQL query in the test does not have much sense per se, but it demonstrates the problem).

```
org.eigenbase.relopt.RelOptPlanner$CannotPlanException: Node [rel#54:Subset#4.ARRAY] could not be implemented; planner state:

Root: rel#54:Subset#4.ARRAY
Original rel:
AbstractConverter(subset=[rel#54:Subset#4.ARRAY], convention=[ARRAY])
  ProjectRel(subset=[rel#49:Subset#4.NONE], CITY=[$4], CITY0=[$14], EMPNO=[$10], EMPNO0=[$0])
    FilterRel(subset=[rel#47:Subset#3.NONE], condition=[AND(=($3, CAST('M'):JavaType(class java.lang.String) NOT NULL), IS NULL($24))])
      JoinRel(subset=[rel#45:Subset#2.NONE], condition=[AND(AND(=($23, CAST('M'):JavaType(class java.lang.String) NOT NULL), =($20, $10)), NOT(CASE(OR(IS NOT NULL($6), IS NOT NULL($26)), AND(AND(AND(IS NOT NULL($6), IS NOT NULL($26)), =($6, $26)), =($4, $24)), AND(OR(IS NULL($1), =($1, CAST('Bob'):JavaType(class java.lang.String) NOT NULL)), OR(IS NULL($21), =($21, CAST('Bob'):JavaType(class java.lang.String) NOT NULL))), =($4, $24), AND(=($1, $21), =($4, $24)), CAST(=(1, 1)):BOOLEAN, null)))], joinType=[left])
        JoinRel(subset=[rel#43:Subset#1.NONE], condition=[=($13, CAST('M'):JavaType(class java.lang.String) NOT NULL)], joinType=[inner])
          CascadingTableAccessRel(subset=[rel#41:Subset#0.CASCADING], table=[[SALES, EMPS]])
          CascadingTableAccessRel(subset=[rel#41:Subset#0.CASCADING], table=[[SALES, EMPS]])
        CascadingTableAccessRel(subset=[rel#41:Subset#0.CASCADING], table=[[SALES, EMPS]])
```
