### PR TITLE
Resolving fields fails in self-join because of missing columns

### DIFF
--- a/lingual-platform/src/test/java/cascading/lingual/jdbc/SimpleSqlPlatformTest.java
+++ b/lingual-platform/src/test/java/cascading/lingual/jdbc/SimpleSqlPlatformTest.java
@@ -337,4 +337,15 @@ public class SimpleSqlPlatformTest extends JDBCPlatformTestCase
 
     assertTablesEqual( "emps-depts-self-join", query );
     }
+  
+  @Test
+  public void testSelfJoin2() throws Exception
+    {
+    String query = "SELECT n1.name, t0.name FROM sales.emps AS t0 INNER JOIN sales.emps AS n1 ON (n1.gender = 'M') " +
+      "WHERE n1.empno = t0.empno";
+
+    // TODO: create correct expected results
+    assertTablesEqual( "emps-depts-self-join", query );
+    }
+  
   }


### PR DESCRIPTION
Hi Chris,

Following the fix from 9bdc898054dcac0c98b42d1d3c0fbaed46492a9c, I am now encountering a new issue where it seems that the projected value columns are dropped during planning. See attached a unit test reproducing the problem.
I have not attached an expected result file (see todo in unit test), as I am not sure what would be the correct output for this query.
