### PR TITLE
Self left join problems in Optiq

### DIFF
--- a/lingual-platform/src/test/java/cascading/lingual/jdbc/SimpleSqlPlatformTest.java
+++ b/lingual-platform/src/test/java/cascading/lingual/jdbc/SimpleSqlPlatformTest.java
@@ -337,4 +337,38 @@ public class SimpleSqlPlatformTest extends JDBCPlatformTestCase
 
     assertTablesEqual( "emps-depts-self-join", query );
     }
+  
+  @Test
+  public void testSelfLeftJoin1() throws Exception
+    {
+    String query = "SELECT q1.empno, p0.empno FROM sales.emps AS p0 " +
+      "LEFT JOIN sales.emps AS q1 ON (q1.gender =  'M') " + 
+      "WHERE p0.gender = 'M' AND p0.city = 'Vancouver' AND p0.deptno = 40 "; 
+
+    assertTablesEqual( "emps-depts-self-join", query );
+    }
+  
+  @Test
+  public void testSelfLeftJoin2() throws Exception
+    {
+    String query = "SELECT q1.empno, p0.empno FROM sales.emps AS p0 " +
+      "LEFT JOIN sales.emps AS q1 ON (q1.gender =  'M' AND p0.city = 'Vancouver' AND p0.deptno = 40) " + 
+      "WHERE p0.gender = 'M' "; 
+
+    assertTablesEqual( "emps-depts-self-join", query );
+    }
+  
+  @Test
+  public void testSelfLeftJoin3() throws Exception
+    {
+    String query = "SELECT q1.empno, p0.empno FROM sales.emps AS p0 " +
+      "LEFT JOIN sales.emps AS q1 ON (q1.gender =  'M' " + 
+      "AND CASE " +
+      "WHEN p0.city = 'Vancouver' AND p0.deptno = 40 " +
+      "THEN  1=1  END) " +
+      "WHERE p0.gender = 'M' "; 
+
+    assertTablesEqual( "emps-depts-self-join", query );
+    }
+  
   }


### PR DESCRIPTION
Here is a set of unit tests showing different issues from Optiq when self left joins are used.
The first unit test, testSelfLeftJoin1, returns a class cast exception.
The second unit test, testSelfLeftJoin2, returns a StackOverflowError.
The third unit test, testSelfLeftJoin3, returns an array IndexOutOfBoundException.
