### PR TITLE
Added License file

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,0 +1,24 @@
+
+License:
+
+  Copyright (c) 2007-2015 Concurrent, Inc. All Rights Reserved.
+
+  Project and contact information: http://www.cascading.org/
+
+  This file is part of the Cascading project.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+Third-party Licenses:
+
+  All third-party dependencies are listed in the gradle.build files.


### PR DESCRIPTION
This revision adds a license file to the project top-level.
This license file is taken from the Cascading/cascading project.

Having the license file here allows the Lingual project to be audited
for open source license compliance independently of the cascading
project.
